### PR TITLE
Fixed API for setQueryEngine in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Setting a query engine host
 For the insertion methods you can set a query selector host (like [qwery](https://github.com/ded/qwery)).
 
 ``` js
-bonzo.setSelectorEngine(qwery);
+bonzo.setQueryEngine(qwery);
 bonzo(bonzo.create('div')).insertAfter('.boosh a');
 ```
 


### PR DESCRIPTION
Was using bonzo for a good-browsers-only project, saw that the README didn't reflect the actual API … or the other way around?
