### PR TITLE
Index missing from .map()'s callback

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -165,7 +165,7 @@
     map: function (fn, reject) {
       var m = [], n, i;
       for (i = 0; i < this.length; i++) {
-        n = fn.call(this, this[i]);
+        n = fn.call(this, this[i], i);
         reject ? (reject(n) && m.push(n)) : m.push(n);
       }
       return m;


### PR DESCRIPTION
Acording to the README the map method callback gets the element and the index as arguments, updated the code to reflect that.
