### PR TITLE
Prevent overwriting element's data, and fix for scrollTop/scrollLeft

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -504,7 +504,7 @@
 
   function scroll(x, y, type) {
     var el = this[0]
-    if (x === null && y === null) {
+    if (x == null && y == null) {
       return (isBody(el) ? getWindowScroll() : { x: el.scrollLeft, y: el.scrollTop })[type]
     }
     if (isBody(el)) {

--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -455,9 +455,8 @@
           return this.each(function (el) {
             el[getAttribute]('data-node-uid') || el[setAttribute]('data-node-uid', ++uuids)
             var uid = el[getAttribute]('data-node-uid')
-              , o = {}
+              , o = uidList[uid] || (uidList[uid] = {})
             o[k] = v
-            uidList[uid] = o
           })
         }
       }


### PR DESCRIPTION
The element's data was being overwritten any time a new value was set.

Also, the strict equality check in the `scroll` function was causing failures when `x` or `y` was `undefined` instead of `null`.
