### PR TITLE
first()/last() safety for empty sets

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -227,11 +227,11 @@
       }
 
     , first: function () {
-        return bonzo(this[0])
+        return this.length ? bonzo(this[0]) : this
       }
 
     , last: function () {
-        return bonzo(this[this.length - 1])
+        return this.length ? bonzo(this[this.length - 1]) : this
       }
 
     , html: function (h, text) {

--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -227,11 +227,11 @@
       }
 
     , first: function () {
-        return this.length ? bonzo(this[0]) : this
+        return bonzo(this.length ? this[0] : [])
       }
 
     , last: function () {
-        return this.length ? bonzo(this[this.length - 1]) : this
+        return bonzo(this.length ? this[this.length - 1] : [])
       }
 
     , html: function (h, text) {

--- a/src/ender.js
+++ b/src/ender.js
@@ -55,11 +55,11 @@
     },
 
     first: function () {
-      return this.length ? $(this[0]) : this
+      return $(this.length ? this[0] : this)
     },
 
     last: function () {
-      return this.length ? $(this[this.length - 1]) : this
+      return $(this.length ? this[this.length - 1] : [])
     },
 
     next: function () {

--- a/src/ender.js
+++ b/src/ender.js
@@ -55,11 +55,11 @@
     },
 
     first: function () {
-      return $(this[0])
+      return this.length ? $(this[0]) : this
     },
 
     last: function () {
-      return $(this[this.length - 1])
+      return this.length ? $(this[this.length - 1]) : this
     },
 
     next: function () {


### PR DESCRIPTION
noticed in older IE but not in Chrome that calling `ender.first()` or `ender.last()` throws an error in `boosh()` because it's sent `undefined`. I'm not sure why Chrome doesn't complain and I haven't investigated other browsers, it just seems prudent to do a simple check so you can do things like $('.nosuchclass').first().show() without getting an error.

`bonzo.first()` and `bonzo.last()` don't suffer from the same problem because `Bonzo()` is `undefined`-safe, but I've included the same pattern in its `first()` and `last()` anyway.

I'll also submit a PR for Ender to make `boosh()` safer.
