### PR TITLE
whoops, typo in the test case

### DIFF
--- a/tests/tests.html
+++ b/tests/tests.html
@@ -541,11 +541,11 @@
           fake = dom({
             attributes: [ { name: 'data-node-uid', value: uid } ],
             getAttribute: function () { return uid }
-          })
+          }).data()
 
           ok(data, 'stored data object is intact after removal')
           ok(data.foo == 'bar', 'data object retains old values')
-          ok(fake.foo === undefined, 'new data object is wiped clean')
+          ok(fake.nodeUid === 2 && fake.foo === undefined, 'new data object is wiped clean')
         })
 
         function testCreate(node) {


### PR DESCRIPTION
As for the CoffeeScript style of the tests, did you mean the weird object hack or the lack of semicolons? The semicolons are because I followed the style of the test case above... the rest of the file seems inconsistent in semicolon use. The weird object hack was necessary because uidMap isn't externally exposed, but maybe it should be. I agree that it's hacky.
