### PR TITLE
Make html() more robust for older versions of IE

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -286,7 +286,10 @@
             this.empty().each(function (el) {
               !text && (m = el.tagName.match(specialTags)) ?
                 append(el, m[0]) :
-                (el[method] = h)
+                !function() {
+                  try { (el[method] = h) }
+                  catch(e) { append(el) }
+                }();
             }) :
           this[0] ? this[0][method] : ''
       }

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -78,7 +78,9 @@
       </div>
       <div id="insert-after-last"><div class="after-last-target"></div></div>
       <div id="html"></div>
-      <p id="html-p"></div>
+      <p id="html-p"></p>
+      <span id="html-span"></span>
+      <p><div id="html-nestdiv"></div></p>
       <div id="html-select"></div>
       <div id="html-table"></div>
       <div id="text"></div>
@@ -223,7 +225,7 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 5, function () {
+        test('get and set html', 7, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
             , fixture3 = '<div>oh yeeeeeah!</div>'
@@ -235,14 +237,32 @@
           $('#html').empty().html(fixture2);
           ok(Q('#html')[0].innerHTML == fixture2, 'sets appropriate tag-less fixture html');
           ok($('#html').html() == fixture2, 'gets appropriate tag-less fixture html');
-
+      
           var ex = false
           try {
             $('#html-p').html(fixture3);
           } catch(e) {
             ex = true
           } finally {
-            ok(!ex, 'setting block-level fixture inside inline element doesn\'t throw exception');
+            ok(!ex, 'setting block-level fixture inside paragraph element doesn\'t throw exception');
+          }
+      
+          ex = false
+          try {
+            $('#html-span').html(fixture3);
+          } catch(e) {
+            ex = true
+          } finally {
+            ok(!ex, 'setting block-level fixture inside span element doesn\'t throw exception');
+          }
+      
+          ex = false
+          try {
+            $('#html-nestdiv').html(fixture3);
+          } catch(e) {
+            ex = true
+          } finally {
+            ok(!ex, 'setting block-level fixture inside block element nested inside paragraph element doesn\'t throw exception');
           }
         });
 

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -223,7 +223,7 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 7, function () {
+        test('get and set html', 9, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
             , fixture3 = '<div>oh yeeeeeah!</div>'
@@ -241,14 +241,16 @@
           try { $('#html-p').html(fixture3); } 
           catch(e) { ex = true } 
           finally { 
-            ok(!ex, 'setting block-level fixture inside paragraph element doesn\'t throw exception'); 
+            ok(!ex, 'setting block-level fixture inside paragraph element doesn\'t throw exception');
+            ok($('#html-p').html() == fixture3, 'block-level element actually got appended to &lt;p&gt;') 
           }
 
           var ex = false
           try { $('#html-p').html(fixture4); } 
           catch(e) { ex = true } 
           finally { 
-            ok(!ex, 'setting inline fixture inside paragraph element doesn\'t throw exception'); 
+            ok(!ex, 'setting inline fixture inside paragraph element doesn\'t throw exception');
+            ok($('#html-p').html() == fixture4, 'inline element actually got appended to &lt;p&gt;');
           }
 
           var ex = false

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -223,7 +223,7 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 6, function () {
+        test('get and set html', 5, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
             , fixture3 = '<div>oh yeeeeeah!</div>'
@@ -236,9 +236,14 @@
           ok(Q('#html')[0].innerHTML == fixture2, 'sets appropriate tag-less fixture html');
           ok($('#html').html() == fixture2, 'gets appropriate tag-less fixture html');
 
-          $('#html-p').html(fixture3);
-          ok(Q('#html-p')[0].innerHTML == fixture3, 'sets block-level fixture html inside inline element');
-          ok($('#html-p').html() == fixture3, 'gets appropriate block-level fixture html from inline element');
+          var ex = false
+          try {
+            $('#html-p').html(fixture3);
+          } catch(e) {
+            ex = true
+          } finally {
+            ok(!ex, 'setting block-level fixture inside inline element doesn\'t throw exception');
+          }
         });
 
         test('set html on special tags', 3, function () {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -79,8 +79,6 @@
       <div id="insert-after-last"><div class="after-last-target"></div></div>
       <div id="html"></div>
       <p id="html-p"></p>
-      <span id="html-span"></span>
-      <p><div id="html-nestdiv"></div></p>
       <div id="html-select"></div>
       <div id="html-table"></div>
       <div id="text"></div>
@@ -225,10 +223,11 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 7, function () {
+        test('get and set html', 6, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
             , fixture3 = '<div>oh yeeeeeah!</div>'
+            , fixture4 = '<span>oh yeeeeeah!</span>'
 
           $('#html').html(fixture);
           ok(Q('#html')[0].innerHTML.toLowerCase() == fixture, 'sets appropriate fixture html');
@@ -246,23 +245,14 @@
           } finally {
             ok(!ex, 'setting block-level fixture inside paragraph element doesn\'t throw exception');
           }
-      
-          ex = false
+
+          var ex = false
           try {
-            $('#html-span').html(fixture3);
+            $('#html-p').html(fixture4);
           } catch(e) {
             ex = true
           } finally {
-            ok(!ex, 'setting block-level fixture inside span element doesn\'t throw exception');
-          }
-      
-          ex = false
-          try {
-            $('#html-nestdiv').html(fixture3);
-          } catch(e) {
-            ex = true
-          } finally {
-            ok(!ex, 'setting block-level fixture inside block element nested inside paragraph element doesn\'t throw exception');
+            ok(!ex, 'setting inline fixture inside paragraph element doesn\'t throw exception');
           }
         });
 

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -237,7 +237,7 @@
           $('#html').empty().html(fixture2);
           ok(Q('#html')[0].innerHTML == fixture2, 'sets appropriate tag-less fixture html');
           ok($('#html').html() == fixture2, 'gets appropriate tag-less fixture html');
-      
+
           var ex = false
           try {
             $('#html-p').html(fixture3);

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -223,7 +223,7 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 6, function () {
+        test('get and set html', 7, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
             , fixture3 = '<div>oh yeeeeeah!</div>'
@@ -238,21 +238,24 @@
           ok($('#html').html() == fixture2, 'gets appropriate tag-less fixture html');
 
           var ex = false
-          try {
-            $('#html-p').html(fixture3);
-          } catch(e) {
-            ex = true
-          } finally {
-            ok(!ex, 'setting block-level fixture inside paragraph element doesn\'t throw exception');
+          try { $('#html-p').html(fixture3); } 
+          catch(e) { ex = true } 
+          finally { 
+            ok(!ex, 'setting block-level fixture inside paragraph element doesn\'t throw exception'); 
           }
 
           var ex = false
-          try {
-            $('#html-p').html(fixture4);
-          } catch(e) {
-            ex = true
-          } finally {
-            ok(!ex, 'setting inline fixture inside paragraph element doesn\'t throw exception');
+          try { $('#html-p').html(fixture4); } 
+          catch(e) { ex = true } 
+          finally { 
+            ok(!ex, 'setting inline fixture inside paragraph element doesn\'t throw exception'); 
+          }
+
+          var ex = false
+          try { var el = $($.create(fixture)).html(fixture)[0]; }
+          catch(e) { ex = true }
+          finally {
+            ok(el && el.innerHTML.toLowerCase().indexOf(fixture) != -1, 'got a &lt;p&gt; into a &lt;p&gt;');
           }
         });
 

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -78,6 +78,7 @@
       </div>
       <div id="insert-after-last"><div class="after-last-target"></div></div>
       <div id="html"></div>
+      <p id="html-p"></div>
       <div id="html-select"></div>
       <div id="html-table"></div>
       <div id="text"></div>
@@ -222,9 +223,10 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 4, function () {
+        test('get and set html', 6, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
+            , fixture3 = '<div>oh yeeeeeah!</div>'
 
           $('#html').html(fixture);
           ok(Q('#html')[0].innerHTML.toLowerCase() == fixture, 'sets appropriate fixture html');
@@ -233,6 +235,10 @@
           $('#html').empty().html(fixture2);
           ok(Q('#html')[0].innerHTML == fixture2, 'sets appropriate tag-less fixture html');
           ok($('#html').html() == fixture2, 'gets appropriate tag-less fixture html');
+
+          $('#html-p').html(fixture3);
+          ok(Q('#html-p')[0].innerHTML == fixture3, 'sets block-level fixture html inside inline element');
+          ok($('#html-p').html() == fixture3, 'gets appropriate block-level fixture html from inline element');
         });
 
         test('set html on special tags', 3, function () {


### PR DESCRIPTION
IE8 will throw a "Unknown Runtime Error" if you attempt to set the innerHTML for a block-level element nested inside a inline-level element (ie. a &lt;div> inside a &lt;p>). 

If we catch an error trying to set the innerHTML, we can fall back on <code>empty()</code>'ing the element and then appending the HTML as an element instead.

This is the same technique that jQuery uses (https://github.com/jquery/jquery/blob/master/src/manipulation.js#L231-243), presumably for the same reason.

Thanks as always for the great micro-libraries. They rock my world.

ps. Here's the earliest mention of this quirk I can find: http://blog.rakeshpai.me/2007/02/ies-unknown-runtime-error-when-using.html
