### PR TITLE
bean integration for remove()

### DIFF
--- a/integration/integration.html
+++ b/integration/integration.html
@@ -41,6 +41,12 @@
             alert('hello')
           })
           .appendTo('body')
+        var evel = $('#evel')
+        evel.listen('removetest', function (event) {
+          $('<div>you should not see me!</div>').appendTo('body')
+        })
+        $('#removable').remove()
+        evel.trigger('removetest')
       });
     </script>
   </head>
@@ -65,6 +71,9 @@
     <div class="hello">world</div>
     <div id="hello-world">
 
+    </div>
+    <div id="removable">
+      <div id="evel"></div>
     </div>
   </body>
 </html>

--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -59,6 +59,7 @@
         function (s) {
           return s.replace(trimReplace, '')
         }
+    , extensions = {}
 
   function classReg(c) {
     return new RegExp("(^|\\s+)" + c + "(\\s+|$)")
@@ -223,6 +224,15 @@
 
   function setter(el, v) {
     return typeof v == 'function' ? v(el) : v
+  }
+
+  function invokeExtensions(type, elements, deep) {
+    var i, l, fns = extensions[type]
+    if (fns && (l = fns.length)) {
+      (deep ? deepEach : each)(elements, function (el) {
+        for (i = 0; i < l; i++) fns[i](el)
+      })
+    }
   }
 
   function Bonzo(elements) {
@@ -423,7 +433,7 @@
       }
 
     , replaceWith: function(html) {
-        this.deepEach(clearData)
+        invokeExtensions('remove', this, true)
 
         return this.each(function (el) {
           el.parentNode.replaceChild(bonzo.create(html)[0], el)
@@ -585,7 +595,7 @@
       }
 
     , remove: function () {
-        this.deepEach(clearData)
+        invokeExtensions('remove', this, true)
 
         return this.each(function (el) {
           el[parentNode] && el[parentNode].removeChild(el)
@@ -594,7 +604,7 @@
 
     , empty: function () {
         return this.each(function (el) {
-          deepEach(el.childNodes, clearData)
+          invokeExtensions('remove', el.childNodes, true)
 
           while (el.firstChild) {
             el.removeChild(el.firstChild)
@@ -731,6 +741,12 @@
       }
       return false
     }
+
+  bonzo._extend = function (type, fn) {
+    (extensions[type] || (extensions[type] = [])).push(fn)
+  }
+
+  bonzo._extend('remove', clearData)
 
   bonzo.noConflict = function () {
     context.bonzo = old

--- a/src/ender.js
+++ b/src/ender.js
@@ -1,7 +1,20 @@
 !function ($) {
 
   var b = require('bonzo')
+    , removeExtension = function (el) {
+        try {
+          var bean = require('bean')
+          !(removeExtension = function (el) {
+            bean.remove(el)
+          })(el)
+        } catch (e) {
+          removeExtension = null
+        }
+      }
+
   b.setQueryEngine($)
+  b._extend('remove', function (el) { removeExtension && removeExtension(el) })
+
   $.ender(b)
   $.ender(b(), true)
   $.ender({

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -577,6 +577,18 @@
           ok(fake.nodeUid === uid && fake.foo === undefined, 'new data object is wiped clean')
         })
 
+        test('removal extensions', 2, function () {
+          var parent = $.create('<p><span></span></p>')[0]
+            , child = parent.childNodes[0]
+            , match = child
+          $('#fixtures').append(parent)
+          dom._extend('remove', function (e) {
+            // first call should match the child, second call should match parent
+            ok(e === match && (match = parent), 'bonzo "remove" extension point added')
+          })
+          $(parent).remove()
+        })
+
         function testCreate(node) {
            var e, ex
            try { e = $.create('<' + node + '>') } catch (e) {}


### PR DESCRIPTION
A pull request for discussion purposes.

Continuing on from the Ender [inter-module communication issue](https://github.com/ender-js/Ender/issues/87), specifically where `bonzo.remove()` can leave you with Bean event handlers still attached so you don't have a proper clean-up.

The approach I've taken here is to create an extension / hooks / callbacks mechanism for Bonzo in the form of `bonzo._extend(type, fn)`. Where `type` is just `'remove'` at the moment but could be easily expanded to other extension points. I've shifted the existing `clearData()` into the extension list and then in the Ender bridge I've lazily detected Bean and if it exists I put in a call to `bean.remove(el)` in the extension list as well so Bean gets to clean up each time an element is removed from the DOM by Bonzo.

What think you?
