### PR TITLE
Fix .after() and .before() to accept sets/arrays of nodes (like other methods)

### DIFF
--- a/bonzo.js
+++ b/bonzo.js
@@ -171,10 +171,22 @@
         var n = !el[parentNode] || (el[parentNode] && !el[parentNode][parentNode]) ?
           function () {
             var c = el.cloneNode(true)
+              , cloneElems
+              , elElems;
+
             // check for existence of an event cloner
             // preferably https://github.com/fat/bean
             // otherwise Bonzo won't do this for you
-            self.$ && self.cloneEvents && self.$(c).cloneEvents(el)
+            if (self.$ && self.cloneEvents) {
+              self.$(c).cloneEvents(el);
+
+              // clone events from every child node
+              cloneElems = self.$(c).find('*');
+              elElems = self.$(el).find('*');
+
+              for (var i = 0; i < elElems.length; i++)
+                self.$(cloneElems[i]).cloneEvents(elElems[i]);
+            }
             return c
           }() : el
         fn(t, n)

--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -112,6 +112,10 @@
     return node && node.nodeName && node.nodeType == 1
   }
 
+  function isArray(obj) {
+      return Object.prototype.toString.call(obj) === '[object Array]'
+  }
+
   function some(ar, fn, scope, i) {
     for (i = 0, j = ar.length; i < j; ++i) if (fn.call(scope, ar[i], i, ar)) return true
     return false
@@ -700,8 +704,8 @@
 
   bonzo.create = function (node) {
     // hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
-    return typeof node == 'string' && node !== '' ?
-      function () {
+    if (typeof node == 'string' && node !== '')
+      return function () {
         var tag = /^\s*<([^\s>]+)/.exec(node)
           , el = doc.createElement('div')
           , els = []
@@ -723,8 +727,15 @@
         // `dep` > 1 can also cause problems with the insert() check (must do this last)
         each(els, function(el) { el[pn] && el[pn].removeChild(el) })
         return els
-
-      }() : isNode(node) ? [node.cloneNode(true)] : []
+      }();
+    if (isNode(node))
+        return [node.cloneNode(true)];
+    if (isArray(node) || node instanceof Bonzo) {
+        var els = [];
+        each(node, function(i) { els.push(bonzo.create(i)[0]); });
+        return els;
+    }
+    return [];
   }
 
   bonzo.doc = function () {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -66,6 +66,10 @@
         <div class="after-examples"></div>
         <div class="after-examples"></div>
       </div>
+      <div id="after-created">
+        <div class="after-created-examples"></div>
+        <div class="after-created-examples"></div>
+      </div>
       <div id="before">
         <div class="before-examples"></div>
         <div class="before-examples"></div>
@@ -205,6 +209,13 @@
           $('.after-examples').after('<span>some <em>shiza</em></span>');
           ok(Q('#after em').length == 2, 'inserted all nodes');
           ok(Q('#after span')[0] == Q('.after-examples')[0].nextSibling, 'inserted node after target');
+        });
+
+        test('should insert created nodes after target', 2, function () {
+          var created = $.create('<span>some <em>shiza</em></span>')
+          $('.after-created-examples').after(created);
+          ok(Q('#after-created em').length == 2, 'inserted all nodes');
+          ok(Q('#after-created span')[0] == Q('.after-created-examples')[0].nextSibling, 'inserted node after target');
         });
 
         test('should insert target before nodes', 1, function () {


### PR DESCRIPTION
Enables the following:

``` javascript
var created = $.create('<span>some <em>shiza</em></span>')
$('.after-created-examples').after(created);
```

This works using a number of other Bonzo methods, so it seemed natural to extend it here. For example, one could do the following just fine:

``` javascript
var created = $.create('<span>some <em>shiza</em></span>')
created.appendTo('.after-created-examples');
```
