### PR TITLE
Fix .after() and .before() to accept sets/arrays of nodes (like other methods)

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -112,6 +112,10 @@
     return node && node.nodeName && node.nodeType == 1
   }
 
+  function isArray(obj) {
+      return Object.prototype.toString.call(obj) === '[object Array]'
+  }
+
   function some(ar, fn, scope, i) {
     for (i = 0, j = ar.length; i < j; ++i) if (fn.call(scope, ar[i], i, ar)) return true
     return false
@@ -308,7 +312,7 @@
       // more related insertion methods
     , append: function (node) {
         return this.each(function (el) {
-          each(normalize(node), function (i) {
+          each(bonzo.create(node), function (i) {
             el.appendChild(i)
           })
         })
@@ -317,7 +321,7 @@
     , prepend: function (node) {
         return this.each(function (el) {
           var first = el.firstChild
-          each(normalize(node), function (i) {
+          each(bonzo.create(node), function (i) {
             el.insertBefore(i, first)
           })
         })
@@ -700,8 +704,8 @@
 
   bonzo.create = function (node) {
     // hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
-    return typeof node == 'string' && node !== '' ?
-      function () {
+    if (typeof node == 'string' && node !== '')
+      return function () {
         var tag = /^\s*<([^\s>]+)/.exec(node)
           , el = doc.createElement('div')
           , els = []
@@ -723,8 +727,15 @@
         // `dep` > 1 can also cause problems with the insert() check (must do this last)
         each(els, function(el) { el[pn] && el[pn].removeChild(el) })
         return els
-
-      }() : isNode(node) ? [node.cloneNode(true)] : []
+      }();
+    if (isNode(node))
+        return [node.cloneNode(true)];
+    if (isArray(node) || node instanceof Bonzo) {
+        var els = [];
+        each(node, function(i) { els.push(bonzo.create(i)[0]); });
+        return els;
+    }
+    return [];
   }
 
   bonzo.doc = function () {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -61,10 +61,6 @@
         <div class="after-examples"></div>
         <div class="after-examples"></div>
       </div>
-      <div id="after-created">
-        <div class="after-created-examples"></div>
-        <div class="after-created-examples"></div>
-      </div>
       <div id="before">
         <div class="before-examples"></div>
         <div class="before-examples"></div>

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -61,6 +61,10 @@
         <div class="after-examples"></div>
         <div class="after-examples"></div>
       </div>
+      <div id="after-created">
+        <div class="after-created-examples"></div>
+        <div class="after-created-examples"></div>
+      </div>
       <div id="before">
         <div class="before-examples"></div>
         <div class="before-examples"></div>
@@ -177,29 +181,69 @@
 
         })
 
-        test('should append nodes', 1, function () {
-          $('#append div').append('<p>hello</p><p>world <a href="#">hunger</a></p>');
-          ok(Q('#append p').length == 4, 'appended two {p} nodes on all elements');
+        test('should append nodes', 3, function () {
+          var markup = '<p>hello</p><p>world <a href="#">hunger</a></p>';
+          var p1 = document.createElement('p');
+          p1.innerHTML = 'hello';
+          var p2 = document.createElement('p');
+          p2.innerHTML = 'world <a href="#">hunger</a>';
+
+          var inputs = [markup, [p1, p2], $.create(markup)];
+
+          for (var i = 0; i < inputs.length; i++) {
+            $('#append div').append(inputs[i]);
+            ok(Q('#append p').length == 4, 'appended two {p} nodes on all elements');
+            $('#append p').remove();
+          }
         });
 
-        test('should prepend nodes', 2, function () {
-          $('#prepend').prepend('<p>hello</p><p>world <a href="#">hunger</a></p>');
-          ok(Q('#prepend p')[0] == Q('#prepend')[0].firstChild, 'prepend two {p} nodes on all elements');
-          ok(Q('#prepend p').length == 2, 'prepended 2 {p} nodes');
+        test('should prepend nodes', 6, function () {
+          var markup = '<p>hello</p><p>world <a href="#">hunger</a></p>';
+          var p1 = document.createElement('p');
+          p1.innerHTML = 'hello';
+          var p2 = document.createElement('p');
+          p2.innerHTML = 'world <a href="#">hunger</a>';
+
+          var inputs = [markup, [p1, p2], $.create(markup)];
+
+          for (var i = 0; i < inputs.length; i++) {
+            $('#prepend').prepend(inputs[i]);
+            ok(Q('#prepend p')[0] == Q('#prepend')[0].firstChild, 'prepend two {p} nodes on all elements');
+            ok(Q('#prepend p').length == 2, 'prepended 2 {p} nodes');
+            $('#prepend p').remove();
+          }
         });
 
-        test('should insert nodes before target', 2, function () {
-          var el = document.createElement('span');
-          el.innerHTML = '<b>some <em>shiza</em></b>';
-          $('.before-examples').before(el);
-          ok(Q('#before span').length == 2, 'inserted all nodes');
-          ok(Q('#before span')[0] == Q('.before-examples')[0].previousSibling, 'target node inserted before collection');
+        test('should insert nodes before target', 6, function () {
+          var markup = '<span><b>some <em>shiza</em></b></span>';
+          var domElem = document.createElement('span');
+          domElem.innerHTML = '<b>some <em>shiza</em></b>';
+
+          var inputs = [markup, domElem, $.create(markup)];
+
+          for (var i = 0; i < inputs.length; i++) {
+            $('.before-examples').before(inputs[i]);
+            ok(Q('#before span').length == 2, 'inserted all nodes');
+            ok(Q('#before span')[0] == Q('.before-examples')[0].previousSibling, 'target node inserted before collection');
+
+            $('#before span').remove(); // cleanup
+          }
         });
 
-        test('should insert nodes after target', 2, function () {
-          $('.after-examples').after('<span>some <em>shiza</em></span>');
-          ok(Q('#after em').length == 2, 'inserted all nodes');
-          ok(Q('#after span')[0] == Q('.after-examples')[0].nextSibling, 'inserted node after target');
+        test('should insert nodes after target', 6, function () {
+          var markup = '<span>some <em>shiza</em></span>';
+          var domElem = document.createElement('span');
+          domElem.innerHTML = 'some <em>shiza</em></span>';
+
+          var inputs = [markup, domElem, $.create(markup)];
+
+          for (var i = 0; i < inputs.length; i++) {
+            $('.after-examples').after(inputs[i]);
+            ok(Q('#after em').length == 2, 'inserted all nodes');
+            ok(Q('#after span')[0] == Q('.after-examples')[0].nextSibling, 'inserted node after target');
+
+            $('#after span').remove(); // cleanup
+          }
         });
 
         test('should insert target before nodes', 1, function () {


### PR DESCRIPTION
Enables the following:

``` javascript
var created = $.create('<span>some <em>shiza</em></span>')
$('.after-created-examples').after(created);
```

This works using a number of other Bonzo methods, so it seemed natural to extend it here. For example, one could do the following just fine:

``` javascript
var created = $.create('<span>some <em>shiza</em></span>')
created.appendTo('.after-created-examples');
```
