### PR TITLE
.html() can insert HTMLElements

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -285,18 +285,18 @@
             'textContent' :
           'innerHTML', m;
         function append(el) {
-          each(normalize(h), function (node) {
-            el.appendChild(node)
-          })
+          if (!text && (typeof h === 'object')) {
+            each(normalize(h), function (node) {
+              el.appendChild(node)
+            })
+          } else {
+            try { (el[method] = h) }
+            catch(e) { append(el) }
+          }
         }
         return typeof h !== 'undefined' ?
             this.empty().each(function (el) {
-              !text && (m = el.tagName.match(specialTags)) ?
-                append(el, m[0]) :
-                !function() {
-                  try { (el[method] = h) }
-                  catch(e) { append(el) }
-                }();
+              append(el)
             }) :
           this[0] ? this[0][method] : ''
       }

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -217,7 +217,7 @@
           ok(Q('.after-last-target')[0].nextSibling && Q('.after-last-target')[0].nextSibling.tagName.toLowerCase() == 'p', 'created element was inserted after the target (target is last child)');
         });
 
-        test('get and set html', 9, function () {
+        test('get and set html', 10, function () {
           var fixture = '<p>oh yeeeeeah!</p>'
             , fixture2 = '&lt;oh yeeeeeah&gt;'
             , fixture3 = '<div>oh yeeeeeah!</div>'
@@ -252,6 +252,13 @@
           catch(e) { ex = true }
           finally {
             ok(el && el.innerHTML.toLowerCase().indexOf(fixture) != -1, 'got a &lt;p&gt; into a &lt;p&gt;');
+          }
+
+          var ex = false
+          try { var el = $($.create(fixture)).html($.create(fixture4))[0]; }
+          catch(e) { ex = true }
+          finally {
+            ok(el && el.innerHTML.toLowerCase().indexOf(fixture4) != -1, 'HTMLElements can be appended');
           }
         });
 


### PR DESCRIPTION
don't know if it was intended, but, calling `$('#id').html($('<div>'))` used `el.innerHTML` instead of `appendChild()` as http://jsfiddle.net/UwzVF/1/

```
var bDiv = bonzo.create('<div>');

bonzo(bDiv).text('bonzo')

bonzo(document.getElementById('bz'))
    .html(bDiv)
```

resulted in:

```
<div id="bz">[object HTMLDivElement]</div>
```

there is a small caveat, in the code I could see a reference to `(m = el.tagName.match(specialTags))` calling `append(el, m[0])`, but `append` used only the first argument `el`, in this patch I removed it. Was it some planned unfinished feature?
