### PR TITLE
Add box-flex as unitless property (including vendor prefixes)

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -56,7 +56,7 @@
     , trimReplace = /(^\s*|\s*$)/g
     , whitespaceRegex = /\s+/
     , toString = String.prototype.toString
-    , unitless = { lineHeight: 1, zoom: 1, zIndex: 1, opacity: 1 }
+    , unitless = { lineHeight: 1, zoom: 1, zIndex: 1, opacity: 1, boxFlex: 1, WebkitBoxFlex: 1, MozBoxFlex: 1 }
     , trim = String.prototype.trim ?
         function (s) {
           return s.trim()


### PR DESCRIPTION
The new css3 box-flex property is unitless. To set this property via the css method it needs to be added to the `unitless` variable.
Maybe there is a better solution for vendor prefixes?
