### PR TITLE
offset() doesn't account for parents' scrollTop & scrollLeft

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -574,6 +574,11 @@
         while (el = el.offsetParent) {
           top = top + el.offsetTop
           left = left + el.offsetLeft
+
+          if (el != document.body) {
+            top -= el.scrollTop
+            left -= el.scrollLeft
+          }
         }
 
         return {

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -398,6 +398,30 @@
           ok($el.offset().left == 0, 'setting "0" doesnt become falsy')
         })
 
+        test('offset + scroll', 2, function () {
+          var $el = $(dom.create('<div/>')).css({
+                width: '100px',
+                height: '100px',
+                'max-height': '100px',
+                overflow: 'scroll',
+                position: 'relative'
+              }).appendTo(document.body)
+
+            , $el2 = $(dom.create('<div/>')).css({
+                position: 'absolute',
+                width: '200px',
+                height: '200px',
+                top: '50px',
+                left: '50px'
+              }).appendTo($el)
+
+          $el[0].scrollTop = 50
+          $el[0].scrollLeft = 50
+
+          ok($el2.offset().top == $el.offset().top, 'account for scrollTop')
+          ok($el2.offset().left == $el.offset().left, 'account for scrollLeft')
+        })
+
         test('offset() returns 0s when element not found', 4, function () {
           var nullSet = $('div.this-element-dont-exist').offset()
           ok(!nullSet.left, 'no offset().left')


### PR DESCRIPTION
In the current version, an element's `offset()` doesn't take into account its parents' `scrollLeft` and `scrollTop`. Those should take that into account, for all elements except the body.

This patch teaches `offset()` to take scrolling into account. I included a couple tests, but they don't test every possible edge case (negative scroll values, for instance) b/c it didn't seem necessary. 

Let me know if it needs more coverage, or if there's some reason we shouldn't be doing this at all. 

ps. This is also how jQuery's `offset()` works, although they use `getBoundingClientRect()` if possible. I haven't looked into the pros/cons of that approach.
