### PR TITLE
Modify isNode to return true for document fragments

### DIFF
--- a/bonzo.js
+++ b/bonzo.js
@@ -122,7 +122,7 @@
   }
 
   function isNode(node) {
-    return node && node.nodeName && node.nodeType == 1
+    return node && node.nodeName && (node.nodeType == 1 || node.nodeType == 11)
   }
 
   function some(ar, fn, scope, i, j) {

--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -117,7 +117,7 @@
   }
 
   function isNode(node) {
-    return node && node.nodeName && node.nodeType == 1
+    return node && node.nodeName && (node.nodeType == 1 || node.nodeType == 11)
   }
 
   function some(ar, fn, scope, i, j) {


### PR DESCRIPTION
It turns out to be useful to treat document fragments like nodes.
Brings bonzo API closer to parity with native DOM's API e.g.
appending a document fragment to an HTMLElement is allowed and
expected.
