### PR TITLE
safer typechecking in .toggle() and .show()

### DIFF
--- a/bonzo.js
+++ b/bonzo.js
@@ -618,8 +618,9 @@
        * @return {Bonzo}
        */
     , show: function (opt_type) {
+        opt_type = typeof opt_type == 'string' ? opt_type : '' 
         return this.each(function (el) {
-          el.style.display = opt_type || ''
+          el.style.display = opt_type
         })
       }
 
@@ -640,10 +641,12 @@
        * @return {Bonzo}
        */
     , toggle: function (opt_callback, opt_type) {
+        if (!this.length) return this
+        opt_type = typeof opt_type == 'string' ? opt_type : '';
         this.each(function (el) {
-          el.style.display = (el.offsetWidth || el.offsetHeight) ? 'none' : opt_type || ''
+          el.style.display = (el.offsetWidth || el.offsetHeight) ? 'none' : opt_type
         })
-        if (opt_callback) opt_callback()
+        if (typeof opt_callback == 'function') opt_callback()
         return this
       }
 

--- a/bonzo.js
+++ b/bonzo.js
@@ -641,13 +641,11 @@
        * @return {Bonzo}
        */
     , toggle: function (opt_callback, opt_type) {
-        if (!this.length) return this
         opt_type = typeof opt_type == 'string' ? opt_type : '';
-        this.each(function (el) {
-          el.style.display = (el.offsetWidth || el.offsetHeight) ? 'none' : opt_type
+        return this.each(function (el) {
+          el.style.display = (el.offsetWidth || el.offsetHeight) ? 'none' : opt_type;
+          typeof opt_callback == 'function' && opt_callback.call(el)
         })
-        if (typeof opt_callback == 'function') opt_callback()
-        return this
       }
 
 


### PR DESCRIPTION
In `.toggle()` I added a `this.length` check so that the optional callback does not get called for empty sets, and I made it so that the callback only gets called if its `typeof` is function. This makes it easier to interchange jQuery and bonzo b/c the `.toggle(duration)` syntax can now be used w/o throwing an error:

``` js
.toggle(null, 'block') // specify a display type w/o supplying a callback
.toggle(47) // same effect as .toggle()
.toggle(47, 'easeInBounce') // same effect as .toggle()
```

Also (a consideration) does it make sense to pass the collection as the scope to the toggle callback?
