### PR TITLE
Support for AMD detection

### DIFF
--- a/bonzo.js
+++ b/bonzo.js
@@ -5,7 +5,7 @@
   */
 (function (name, context, definition) {
   if (typeof module != 'undefined' && module.exports) module.exports = definition()
-  else if (typeof context['define'] == 'function' && context['define']['amd']) define(definition)
+  else if (typeof define == 'function' && define.amd) define(definition)
   else context[name] = definition()
 })('bonzo', this, function() {
   var win = window

--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -1,6 +1,6 @@
 (function (name, context, definition) {
   if (typeof module != 'undefined' && module.exports) module.exports = definition()
-  else if (typeof context['define'] == 'function' && context['define']['amd']) define(definition)
+  else if (typeof define == 'function' && define.amd) define(definition)
   else context[name] = definition()
 })('bonzo', this, function() {
   var win = window


### PR DESCRIPTION
Currently, Bonzo detects the amd environment using `context['amd']`. When using systems that need to detect if a module is amd or not, this stops a simple regex (checking for the existence of `define.amd` in the text) from being able to detect amd properly.

For example, this is used by the Volo package manager to detect if a module needs to have its globals wrapped, which was being triggered by bonzo.

This small change adjusts the define form to support this.
