### PR TITLE
Fix for #116

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -929,7 +929,7 @@
        * @return {Bonzo|string}
        */
     , val: function (s) {
-        return (typeof s == 'string') ?
+        return (typeof s == 'string' || typeof s == 'number') ?
           this.attr('value', s) :
           this.length ? this[0].value : null
       }

--- a/tests/attributes-test.js
+++ b/tests/attributes-test.js
@@ -137,6 +137,8 @@ sink('Element attributes', function (test, ok) {
     ok(input.attr('value', 'boosh').attr('value') == 'boosh', 'sets value attribute of input')
     input.val('eyoeyo')
     ok(input.val() == 'eyoeyo', 'val(val) can set value on input')
+    input.val(1234)
+    ok(input.val() == '1234', 'val(val) can set number value on input')
   })
 
   test('setting attributes using object', 2, function () {


### PR DESCRIPTION
Originally, the .val() method only allowed the setting of values if they were strings. This should also allow numbers as the passed in argument.
