### PR TITLE
Call setters with the element as scope.

### DIFF
--- a/src/bonzo.js
+++ b/src/bonzo.js
@@ -326,11 +326,11 @@
    * })
    *
    * @param {Element} el
-   * @param {function (Element)|string}
+   * @param {function (Element)|string} v
    * @return {string}
    */
   function setter(el, v) {
-    return typeof v == 'function' ? v(el) : v
+    return typeof v == 'function' ? v.call(el, el) : v
   }
 
   function scroll(x, y, type) {


### PR DESCRIPTION
Conceptually I prefer how bonzo puts the `el` as argument 0 rather than the index like jQuery does. Duplicating the `el` as the scope facilitates writing code for the most common usage (using the element, not the index) that is compatible with both libs.

This allows:

``` js
.addClass(function(el) {
     el = this;
})
```

rather than:

``` js
.addClass(function(el) {
     el = typeof el == 'number' ? this : el;
})
```
